### PR TITLE
Handle 29-bit frame IDs

### DIFF
--- a/DataLoadCAN/dataload_can.cpp
+++ b/DataLoadCAN/dataload_can.cpp
@@ -115,6 +115,11 @@ bool DataLoadCAN::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef& 
     }
     QRegularExpressionMatch canFrame = rxIterator.next();
     uint64_t frameId = std::stoul(canFrame.captured(3).toStdString(), 0, 16);
+    if (canFrame.capturedLength(3) == 8)
+    {
+      // Extended (29-bit) address. Mark it as such, .dbc-style, with bit 31 == '1'
+      frameId |= 0x0000000080000000;
+    }
     double frameTime = std::stod(canFrame.captured(1).toStdString());
 
     int dlc = canFrame.capturedLength(4) / 2;


### PR DESCRIPTION
When loading CAN log data with raw protocol, use bit 31 of the CAN ID to flag extended (29-bit) CAN addresses. This lets PlotJuggler correctly match up logged CAN frames with the CAN IDs carried in `.dbc` files, which use the same technique (setting bit 31) to flag extended addresses.

See https://github.com/PlotJuggler/plotjuggler-CAN-dbs/issues/19