### PR TITLE
Put message names in signal table and plot keys

### DIFF
--- a/PluginsCommonCAN/CanFrameProcessor.cpp
+++ b/PluginsCommonCAN/CanFrameProcessor.cpp
@@ -70,8 +70,10 @@ bool CanFrameProcessor::ProcessCanFrameRaw(const uint32_t frame_id, const uint8_
           (mux_sig && (mux_sig->Decode(data_ptr) == sig.MultiplexerSwitchValue())))
       {
         double decoded_val = sig.RawToPhys(sig.Decode(data_ptr));
-        auto str = QString("can_frames/%1/%2")
-                       .arg(QString::number(msg->Id()), QString::fromStdString(sig.Name()))
+        auto str = QString("can_frames/%1 (%2)/%3")
+                       .arg(QString::fromStdString(msg->Name()),
+                            QString::number(msg->Id()),
+                            QString::fromStdString(sig.Name()))
                        .toStdString();
         // qCritical() << str.c_str();
         auto it = data_map_.numeric.find(str);


### PR DESCRIPTION
UI enhancement:

In the `Timeseries List` pane, display the CAN message names along with their frame IDs. This makes it much easier to locate message and signals of interest:

Baseline:
<img width="973" height="863" alt="CAN-baseline" src="https://github.com/user-attachments/assets/bf510547-d5ad-4241-8cf0-fada25e2ac8d" />

With this change:
<img width="973" height="863" alt="CAN-With-labels" src="https://github.com/user-attachments/assets/81591b10-93b8-4740-a584-cdcbcb47577f" />


